### PR TITLE
Add Capture ButtonMapping as a quick fix for Switch Pro controllers

### DIFF
--- a/src/libs/InputHandler/VirtualController.js
+++ b/src/libs/InputHandler/VirtualController.js
@@ -126,9 +126,9 @@ export default class VirtualController {
 					new ButtonMapping("left"),
 					new ButtonMapping("right"),
 					new ButtonMapping("home"),
+					new ButtonMapping("capture"),
 
 					// extra:
-					new ButtonMapping("a"),
 					new ButtonMapping("a"),
 					new ButtonMapping("a"),
 					new ButtonMapping("a"),


### PR DESCRIPTION
Switch Pro controller has 18 buttons, so the extra ButtonMapping entries map the Capture button (the very last button) to "a" rather than allowing the A button to map to "a". Any controller with too many buttons will have 'a' overridden to the last button, so this is only a quick fix for Switch Pro specifically, and instead this logic should be updated to allow multiple physical buttons to map to the same virtual button.

I believe the PS4 controller also has 18 buttons and suffers from a similar problem. The Xbox controller has 17 and shouldn't encounter this issue.